### PR TITLE
fix log level and a typo

### DIFF
--- a/tsqa/log.py
+++ b/tsqa/log.py
@@ -17,9 +17,23 @@
 import logging
 import os
 
-logging.root.setLevel(os.environ.get('TSQA_LOG_LEVEL', logging.INFO))
+levels = {
+    'CRITICAL': logging.CRITICAL,
+    'ERROR': logging.ERROR,
+    'WARNING': logging.WARNING,
+    'INFO': logging.INFO,
+    'DEBUG': logging.DEBUG}
+
+level = os.environ.get('TSQA_LOG_LEVEL', 'INFO')
+try:
+    level = levels[os.environ.get('TSQA_LOG_LEVEL', 'INFO')]
+except KeyError:
+    logging.error('Unkown log level: %s in environment variable TSQA_LOG_LEVEL', os.environ.get('TSQA_LOG_LEVEL'))
+    level = logging.INFO
+
+logging.root.setLevel(level)
 handler = logging.StreamHandler()
-handler.setLevel(os.environ.get('TSQA_LOG_LEVEL', logging.INFO))
+handler.setLevel(level)
 handler.setFormatter(logging.Formatter("%(levelname)s %(asctime)-15s - %(message)s"))
 logging.root.addHandler(handler)
 

--- a/tsqa/test_cases.py
+++ b/tsqa/test_cases.py
@@ -46,7 +46,7 @@ class EnvironmentCase(unittest.TestCase):
     def run(self, result=None):
         unittest.TestCase.run(self, result)
         # we want to keep track of failures at a class level-- not instance level
-        self.__class__.__successful &= result.result.wasSuccessful()
+        self.__class__.__successful &= result.wasSuccessful()
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
1. Seems that `export TSQA_LOG_LEVEL=DEBUG` from shell does not work. `os.environ.get('TSQA_LOG_LEVEL', logging.INFO)` get a string `DEBUG`, but not an integer `logging.INFO`, which is `10`.
2. remove result, just a typo.
