### PR TITLE
fix the env setting of LD_LIBRARY_PATH/DYLD_LIBRARY_PATH

### DIFF
--- a/tsqa/environment.py
+++ b/tsqa/environment.py
@@ -273,8 +273,9 @@ class Environment(object):
         for env_key in ('LD_LIBRARY_PATH',  # for *nix
                         'DYLD_LIBRARY_PATH',  # for mac
                         ):
-            if environ.has_key(env_key) and self.layout.libdir not in environ[env_key].split(':'):
-                environ[env_key] = self.layout.libdir + ':' + environ[env_key]
+            if environ.has_key(env_key):
+                if self.layout.libdir not in environ[env_key].split(':'):
+                    environ[env_key] = self.layout.libdir + ':' + environ[env_key]
             else:
                 environ[env_key] = self.layout.libdir
 


### PR DESCRIPTION
Hi @jacksontj ,
When we have some external dependency and need to export LD_LIBRARY_PATH for some external libs, TSQA runs into this logic. I think we are trying to merge user's env LD_LIBRARY_PATH and self.layout.libdir.